### PR TITLE
Improving the polygon selector script, pt. 3

### DIFF
--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -127,7 +127,13 @@ def process_polygon(pts, polygon_num, ax, cube, output_dir, args, used_colors, c
 
     # Draw the polygon on the image with its assigned color
     color = used_colors[polygon_num - 1] if polygon_num <= len(used_colors) else colors[polygon_num % len(colors)]
+    
+    # Draw the polygon edges
     ax.plot(c, r, '-', linewidth=2, color=color)
+    
+    # Draw the closing edge if we have at least 3 points
+    if len(pts) > 2:
+        ax.plot([c[-1], c[0]], [r[-1], r[0]], '-', linewidth=2, color=color)
     
     # Calculate and plot the centroid with the label
     centroid_x = np.mean(c)
@@ -250,6 +256,13 @@ def continue_to_polygon(event):
     def on_key(event):
         global drawing_polygon, current_points
         if event.key == 'enter' and current_points:
+            # Draw the closing edge from last point to first point
+            if len(current_points) > 2:  # Only draw closing edge if we have at least 3 points
+                color = used_colors[-1]  # Use the same color as the polygon
+                ax.plot([current_points[-1][0], current_points[0][0]], 
+                       [current_points[-1][1], current_points[0][1]], '-', color=color)
+                fig.canvas.draw_idle()
+            
             print(f"\nProcessing polygon {len(all_pts) + 1} with {len(current_points)} points")
             # Store the current points before clearing
             pts_to_process = current_points.copy()
@@ -260,6 +273,13 @@ def continue_to_polygon(event):
         elif event.key == 'q':
             # Process any remaining points before quitting
             if current_points:
+                # Draw the closing edge from last point to first point
+                if len(current_points) > 2:  # Only draw closing edge if we have at least 3 points
+                    color = used_colors[-1]  # Use the same color as the polygon
+                    ax.plot([current_points[-1][0], current_points[0][0]], 
+                           [current_points[-1][1], current_points[0][1]], '-', color=color)
+                    fig.canvas.draw_idle()
+                
                 print(f"\nProcessing final polygon {len(all_pts) + 1} with {len(current_points)} points")
                 pts_to_process = current_points.copy()
                 all_pts.append(pts_to_process)
@@ -365,7 +385,6 @@ def load_polygons(event):
         
         def on_no(event):
             plt.close(dialog_fig)
-            print("Spectrum plots not shown. Main window remains active.")
         
         yes_button.on_clicked(on_yes)
         no_button.on_clicked(on_no)

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -339,9 +339,21 @@ def load_polygons(event):
         fig.canvas.draw_idle()
         print(f"\nLoaded {len(all_pts)} polygons from CSV files.")
         
-        # Ask user if they want to see the spectra
-        response = input("\nWould you like to see the spectrum plots? (y/n): ")
-        if response.lower() == 'y':
+        # Create a new figure for the button dialog
+        dialog_fig = plt.figure(figsize=(4, 2))
+        dialog_ax = dialog_fig.add_subplot(111)
+        dialog_ax.text(0.5, 0.6, "Would you like to see the spectrum plots?",
+                      ha='center', va='center', transform=dialog_ax.transAxes)
+        dialog_ax.set_axis_off()
+        
+        # Create buttons
+        ax_yes = plt.axes([0.3, 0.2, 0.2, 0.2])
+        ax_no = plt.axes([0.6, 0.2, 0.2, 0.2])
+        yes_button = Button(ax_yes, 'Yes')
+        no_button = Button(ax_no, 'No')
+        
+        def on_yes(event):
+            plt.close(dialog_fig)
             # Enable interactive mode for non-blocking plots
             plt.ion()
             # Second pass: show spectra for each polygon
@@ -349,7 +361,15 @@ def load_polygons(event):
                 process_polygon(pts, i, ax, cube, output_dir, args, used_colors, colors, save_data=False, show_spectrum=True)
             # Keep the plots open
             plt.ioff()
-            plt.show()
+            plt.show(block=False)
+        
+        def on_no(event):
+            plt.close(dialog_fig)
+            print("Spectrum plots not shown. Main window remains active.")
+        
+        yes_button.on_clicked(on_yes)
+        no_button.on_clicked(on_no)
+        plt.show(block=True)
     else:
         print("\nNo existing polygon files found.")
 


### PR DESCRIPTION
This PR fixes a few minor bugs and addresses some of the easier-to-implement feature requests:

**(1) Do not close session unexpectedly**

On clicking the "Load Polygon Data", we now redraw the saved polygons and open a new dialog window asking the user whether or not they want to visualize their reflectance data. Clicking "No" simply closes the dialog window (with the polygons still there), instead of closing the whole session. (Fixes #5.)

**(2) Do not overwrite saved data**

We now check for the presence of previously saved output files, and adjust polygon numbering accordingly. If the `OUTPUT` folder already contains CSV files for polygons 1 through _n_, the first newly drawn polygon will be numbered _n_ + 1. (Fixes #6.)

**(3) Complete the polygons visually**

On pressing Enter, draw an extra edge between the last vertex and the first vertex, thus closing the polygon. Similarly, draw this extra edge when redrawing polygons from previously saved data. (Fixes #8.)

**(4) Saved the coordinates of the 100 randomly selected pixels**

Instead of producing a CSV file of 110 rows (one for each spectral band) and 101 columns (with the 1st one recording the wavelength and the remaining ones recording the reflectances), we now output a file of 100 rows (one for each pixel) and 112 columns (for the _x_- and _y_-coordinates and then for the reflectances). @michaelalfaro's original request was to record the pixel coordinates in column names, but this seems easier to parse and does not require us to transpose the array before printing it out. However, I'm happy to change it if the format doesn't work. (Fixes #10.)