### PR TITLE
Improving the polygon selector script, pt. 5

### DIFF
--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -943,6 +943,27 @@ def load_polygons(event):
 def toggle_edit_mode(event):
     global edit_mode, selected_polygon_num
     if not edit_mode:  # Only show dialog when entering edit mode
+        if not all_polygons:
+            # Create a new figure for the error message
+            dialog_fig = plt.figure(figsize=(3, 2))
+            dialog_ax = dialog_fig.add_subplot(111)
+            dialog_ax.text(0.5, 0.7, "No polygons available to edit.",
+                          ha='center', va='center', transform=dialog_ax.transAxes)
+            dialog_ax.text(0.5, 0.5, "Please draw or load polygons first.",
+                          ha='center', va='center', transform=dialog_ax.transAxes)
+            dialog_ax.set_axis_off()
+            
+            # Create OK button
+            ax_ok = plt.axes([0.4, 0.2, 0.2, 0.2])
+            ok_button = Button(ax_ok, 'OK')
+            
+            def on_ok(event):
+                plt.close(dialog_fig)
+            
+            ok_button.on_clicked(on_ok)
+            plt.show(block=True)
+            return
+
         # Create a new figure for the dialog
         dialog_fig = plt.figure(figsize=(3, 4))
         dialog_ax = dialog_fig.add_subplot(111)

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -511,35 +511,13 @@ def on_key(event):
         
         # Clear current points but preserve history
         current_points.clear()
-        print(f"History length after completing polygon: {len(vertex_history)}")
         redraw_all_polygons()
     elif event.key == 'q':
-        # Process any remaining points before quitting
+        # Just clear any unfinalized points without processing them
         if current_points:
-            # Get the next polygon number
-            polygon_num = get_next_polygon_number(output_dir, args)
-            # Get the color for this polygon number
-            color = get_color_for_polygon(polygon_num)
-            
-            # Draw the closing edge from last point to first point
-            if len(current_points) > 2:  # Only draw closing edge if we have at least 3 points
-                ax.plot([current_points[-1][0], current_points[0][0]], 
-                       [current_points[-1][1], current_points[0][1]], '-', color=color)
-                fig.canvas.draw_idle()
-            
-            print(f"\nProcessing final polygon {polygon_num} with {len(current_points)} points")
-            pts_to_process = current_points.copy()
-            
-            # Add to all_polygons dictionary
-            all_polygons[polygon_num] = {
-                'points': pts_to_process,
-                'color': color
-            }
-            
-            update_polygon_data(polygon_num, pts_to_process, color)
             current_points.clear()
-            print(f"History length after quitting: {len(vertex_history)}")
             redraw_all_polygons()
+        
         print(f"\nTotal polygons processed: {len(all_polygons)}")
         drawing_polygon = False
         # Only disconnect if the connection IDs exist
@@ -705,7 +683,6 @@ def continue_to_polygon(event):
         current_points.append((event.xdata, event.ydata))
         # Store the action in history for undo
         vertex_history.append(('add', len(current_points) - 1, (event.xdata, event.ydata)))
-        print(f"Added vertex to drawing history. Total history length: {len(vertex_history)}")
         # Get the next polygon number
         polygon_num = get_next_polygon_number(output_dir, args)
         # Get the color for this polygon number

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -119,18 +119,18 @@ ax.set_title("Adjust sliders, then click 'Continue to Polygon'")
 ax_radio = plt.axes([0.02, 0.66, 0.25, 0.25], frameon=True)  # Radio buttons at the top
 
 # Sliders below radio buttons - made shorter to fit labels
-ax_low = plt.axes([0.07, 0.53, 0.2, 0.03])
-ax_high = plt.axes([0.07, 0.48, 0.2, 0.03])
-ax_gain = plt.axes([0.07, 0.43, 0.2, 0.03])
-ax_offset = plt.axes([0.07, 0.38, 0.2, 0.03])
+ax_low = plt.axes([0.07, 0.56, 0.2, 0.03])
+ax_high = plt.axes([0.07, 0.51, 0.2, 0.03])
+ax_gain = plt.axes([0.07, 0.46, 0.2, 0.03])
+ax_offset = plt.axes([0.07, 0.41, 0.2, 0.03])
 
 # Buttons at the bottom
-ax_reset = plt.axes([0.02, 0.25, 0.25, 0.04])
-ax_save = plt.axes([0.02, 0.2, 0.25, 0.04])
-ax_continue = plt.axes([0.02, 0.15, 0.25, 0.04])
-ax_load = plt.axes([0.02, 0.1, 0.25, 0.04])
-ax_edit = plt.axes([0.02, 0.05, 0.25, 0.04])  # New Edit Polygon button
-ax_auto = plt.axes([0.02, 0.0, 0.25, 0.04])   # New Extract Specimen button
+ax_reset = plt.axes([0.02, 0.31, 0.25, 0.04])
+ax_save = plt.axes([0.02, 0.26, 0.25, 0.04])
+ax_continue = plt.axes([0.02, 0.21, 0.25, 0.04])
+ax_load = plt.axes([0.02, 0.16, 0.25, 0.04])
+ax_edit = plt.axes([0.02, 0.11, 0.25, 0.04])
+ax_auto = plt.axes([0.02, 0.06, 0.25, 0.04])
 
 # Sliders
 low_slider = Slider(ax_low, 'Low %', 0, 10, valinit=1)

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -97,6 +97,10 @@ current_points = []  # List to store points for the current polygon being drawn
 dragging_vertex = None  # Track which vertex is being dragged
 current_polygon = None  # Track the current polygon being edited
 current_polygon_num = None  # Track the number of the current polygon being edited
+cid_click = None  # Connection ID for click events
+cid_key = None  # Connection ID for key events
+cid_motion = None  # Connection ID for motion events
+cid_release = None  # Connection ID for release events
 
 # Create a colormap with 10 distinct colors from hsv
 colors = plt.cm.hsv(np.linspace(0, 1, 10))
@@ -478,6 +482,7 @@ def redraw_all_polygons(current_points=None, current_color=None):
 
 def on_key(event):
     global drawing_polygon, current_points, vertex_history, edit_mode, selected_polygon_num
+    global cid_click, cid_key, cid_motion, cid_release
     
     if event.key == 'enter' and current_points:
         # Get the next polygon number
@@ -537,10 +542,15 @@ def on_key(event):
             redraw_all_polygons()
         print(f"\nTotal polygons processed: {len(all_polygons)}")
         drawing_polygon = False
-        plt.disconnect(cid_click)
-        plt.disconnect(cid_key)
-        plt.disconnect(cid_motion)
-        plt.disconnect(cid_release)
+        # Only disconnect if the connection IDs exist
+        if cid_click is not None:
+            plt.disconnect(cid_click)
+        if cid_key is not None:
+            plt.disconnect(cid_key)
+        if cid_motion is not None:
+            plt.disconnect(cid_motion)
+        if cid_release is not None:
+            plt.disconnect(cid_release)
     elif event.key == 'cmd+z':  # Check for the combined key event
         if vertex_history:
             # Get the last action from history

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -544,9 +544,7 @@ def on_key(event):
     elif event.key == 'cmd+z':  # Check for the combined key event
         if vertex_history:
             # Get the last action from history
-            print("Removing a vertex from history: global on_key()")
             action = vertex_history.pop()
-            print(f"Undoing action: {action[0]}. Remaining history length: {len(vertex_history)}")
             if action[0] == 'add':
                 # Remove the last vertex from current polygon being drawn
                 if current_points:  # Only pop if we have points
@@ -568,7 +566,6 @@ def on_key(event):
                     redraw_all_polygons()
                     # Update the spectrum
                     update_polygon_data(polygon_num, polygon_points, all_polygons[polygon_num]['color'])
-                    print(f"\nUndid last vertex addition for Polygon {polygon_num}")
 
 def continue_to_polygon(event):
     global final_rgb, current_points, drawing_polygon, dragging_vertex, current_polygon, current_polygon_num, all_polygons, spectrum_figs
@@ -580,9 +577,6 @@ def continue_to_polygon(event):
     # Only clear history if we're starting fresh (no current points)
     if not current_points:
         vertex_history = []
-        print("Starting fresh - cleared vertex history")
-    else:
-        print(f"Continuing with existing history. Current history length: {len(vertex_history)}")
     
     low = low_slider.val
     high = high_slider.val
@@ -688,7 +682,6 @@ def continue_to_polygon(event):
             polygon_points.append((event.xdata, event.ydata))
             # Store the action in history for undo
             vertex_history.append(('add_edit', selected_polygon_num, len(polygon_points) - 1, (event.xdata, event.ydata)))
-            print(f"Added vertex to edit history. Total history length: {len(vertex_history)}")
             # Update the polygon data
             all_polygons[selected_polygon_num]['points'] = polygon_points
             # Redraw all polygons
@@ -885,7 +878,6 @@ def load_polygons(event):
                 polygon_points.append((event.xdata, event.ydata))
                 # Store the action in history for undo
                 vertex_history.append(('add_edit', selected_polygon_num, len(polygon_points) - 1, (event.xdata, event.ydata)))
-                print(f"Added vertex to edit history. Total history length: {len(vertex_history)}")
                 # Update the polygon data
                 all_polygons[selected_polygon_num]['points'] = polygon_points
                 # Redraw all polygons

--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -693,6 +693,9 @@ def continue_to_polygon(event):
             all_polygons[selected_polygon_num]['points'] = polygon_points
             # Redraw all polygons
             redraw_all_polygons()
+            # Update the spectrum immediately after adding the vertex
+            update_polygon_data(selected_polygon_num, polygon_points, all_polygons[selected_polygon_num]['color'])
+            print(f"\nUpdated polygon {selected_polygon_num} and saved changes to CSV files.")
             return
 
         # If not in edit mode and not dragging, add a new point for a new polygon
@@ -887,6 +890,9 @@ def load_polygons(event):
                 all_polygons[selected_polygon_num]['points'] = polygon_points
                 # Redraw all polygons
                 redraw_all_polygons()
+                # Update the spectrum immediately after adding the vertex
+                update_polygon_data(selected_polygon_num, polygon_points, all_polygons[selected_polygon_num]['color'])
+                print(f"\nUpdated polygon {selected_polygon_num} and saved changes to CSV files.")
                 return
 
         def on_release(event):


### PR DESCRIPTION
This PR adds some new functionality requested by @rosamariorduna, and expands existing functionality:

**(1) Add an "Undo" action**

We can now press Cmd+Z to undo the addition of a new vertex. We can do this both when drawing a new polygon and when editing an existing polygon. In the former case, we can undo the vertex additions one by one until the whole polygon is removed; in the latter case, we can remove all the vertices added in the current round of editing (i.e., we cannot remove the vertices we loaded from previously saved data).

(Closes #14.)

**(2) Dedicated "Edit mode" to insert new vertices into existing polygons**

We can still add and drag vertices as we please, but once we have finalized a polygon and generated its reflectance plot by pressing Return, we can only make further changes by entering a dedicated edit mode. This is done by clicking a newly added button called "Edit Polygon", which opens a dialog box asking the user which polygon they wish to edit. The choices correspond to all currently visible polygons. If we click the button before any polygons have been drawn, we display an error message. The edit mode always allows us to only edit one polygon at a time. If you click a vertex of a polygon other than the one you are currently editing, a warning is printed to the console. Most importantly, this allows us to change the shape of finalized / saved polygons not only by dragging their existing vertices, but also by inserting new vertices. In edit mode, dragging an existing vertex or inserting a new one automatically updates the polygon's reflectance plot in real time.

(Closes #7.)