### PR TITLE
Improving the polygon selector script, pt. 6

### DIFF
--- a/poly-selector/SCRIPTS/extract-reflectance-gui.py
+++ b/poly-selector/SCRIPTS/extract-reflectance-gui.py
@@ -119,18 +119,18 @@ ax.set_title("Adjust sliders, then click 'Continue to Polygon'")
 ax_radio = plt.axes([0.02, 0.66, 0.25, 0.25], frameon=True)  # Radio buttons at the top
 
 # Sliders below radio buttons - made shorter to fit labels
-ax_low = plt.axes([0.07, 0.53, 0.2, 0.03])
-ax_high = plt.axes([0.07, 0.48, 0.2, 0.03])
-ax_gain = plt.axes([0.07, 0.43, 0.2, 0.03])
-ax_offset = plt.axes([0.07, 0.38, 0.2, 0.03])
+ax_low = plt.axes([0.07, 0.56, 0.2, 0.03])
+ax_high = plt.axes([0.07, 0.51, 0.2, 0.03])
+ax_gain = plt.axes([0.07, 0.46, 0.2, 0.03])
+ax_offset = plt.axes([0.07, 0.41, 0.2, 0.03])
 
 # Buttons at the bottom
-ax_reset = plt.axes([0.02, 0.25, 0.25, 0.04])
-ax_save = plt.axes([0.02, 0.2, 0.25, 0.04])
-ax_continue = plt.axes([0.02, 0.15, 0.25, 0.04])
-ax_load = plt.axes([0.02, 0.1, 0.25, 0.04])
-ax_edit = plt.axes([0.02, 0.05, 0.25, 0.04])  # New Edit Polygon button
-ax_auto = plt.axes([0.02, 0.0, 0.25, 0.04])   # New Extract Specimen button
+ax_reset = plt.axes([0.02, 0.31, 0.25, 0.04])
+ax_save = plt.axes([0.02, 0.26, 0.25, 0.04])
+ax_continue = plt.axes([0.02, 0.21, 0.25, 0.04])
+ax_load = plt.axes([0.02, 0.16, 0.25, 0.04])
+ax_edit = plt.axes([0.02, 0.11, 0.25, 0.04])
+ax_auto = plt.axes([0.02, 0.06, 0.25, 0.04])
 
 # Sliders
 low_slider = Slider(ax_low, 'Low %', 0, 10, valinit=1)


### PR DESCRIPTION
This PR adds an image segmentation feature powered by `scikit-image` to automatically isolate the specimen from its background.

Specifically, the PR adds a new button, "Extract Specimen", which is roughly analogous to the Magic Wand tool in Photoshop and similar image editors. When clicked, it (1) automatically creates a new polygon demarcating the body of the specimen, and (2) opens a dialog window with a slider to adjust the threshold that controls how pixels are to be grouped together. The polygon is updated in real time as the slider is moved to facilitate finding the right threshold value. Low values correspond to more aggressive grouping and usually produce better results; high values discriminate more stringently.

Once the user is happy with their choice of the threshold value, they should press Return, which (1) confirms the choice and closes the dialog window, (2) generates a reflectance plot for the resulting polygon, and (3) saves the corresponding data to (vertex coordinates, reflectance mean and standard deviation, 100 randomly selected points) to CSV files. At this point, the output has become a regular polygon that can be manipulated like any other, and the user can enter Edit mode to change its shape, insert new vertices, or undo such additions using Cmd+Z.

(Closes #9.)